### PR TITLE
add start process dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ yarn add svelte-file-dropzone
 | dragover         |             | `{dragEvent: event}`                   |
 | dragleave        |             | `{dragEvent: event}`                   |
 | drop             |             | `{acceptedFiles,fileRejections,event}` |
+| filedropped      |             | `{event}`                              |
 | droprejected     |             | `{fileRejections,event}`               |
 | dropaccepted     |             | `{acceptedFiles,event}`                |
 | filedialogcancel |             |                                        |

--- a/src/components/Dropzone.svelte
+++ b/src/components/Dropzone.svelte
@@ -182,7 +182,7 @@
     dragTargetsRef = [];
 
     if (isEvtWithFiles(event)) {
-      dispatch("startprocess", {
+      dispatch("filedropped", {
         event
       })
       Promise.resolve(getFilesFromEvent(event)).then(files => {

--- a/src/components/Dropzone.svelte
+++ b/src/components/Dropzone.svelte
@@ -182,6 +182,9 @@
     dragTargetsRef = [];
 
     if (isEvtWithFiles(event)) {
+      dispatch("startprocess", {
+        event
+      })
       Promise.resolve(getFilesFromEvent(event)).then(files => {
         if (isPropagationStopped(event) && !noDragEventsBubbling) {
           return;


### PR DESCRIPTION
It is not known when the process started because the `on:drop callback` is called only after the Promise. 
So I added it so that it can be dispatched once before Promise.

related #5 