### PR TITLE
Fix code highlighting in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add svelte-file-dropzone
 
 ## Usage
 
-```
+```svelte
 <script>
   import Dropzone from "svelte-file-dropzone";
 


### PR DESCRIPTION
Hi there,

It seems that this 
```
<script>
  import Dropzone from "svelte-file-dropzone";

  let files = {
    accepted: [],
    rejected: []
  };

  function handleFilesSelect(e) {
    const { acceptedFiles, fileRejections } = e.detail;
    files.accepted = [...files.accepted, ...acceptedFiles];
    files.rejected = [...files.rejected, ...fileRejections];
  }
</script>

<Dropzone on:drop={handleFilesSelect} />
<ol>
  {#each files.accepted as item}
    <li>{item.name}</li>
  {/each}
</ol>
```
code block should be wrapped in `svelte` tag. 

This pull request essentially fixes that. Have a good day :)