### PR TITLE
Fix class selector in Fully Featured example

### DIFF
--- a/stories/views/FullyFeaturedDropzoneView.svelte
+++ b/stories/views/FullyFeaturedDropzoneView.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <style>
-  :global(custom-dropzone) {
+  :global(.custom-dropzone) {
   }
 </style>
 


### PR DESCRIPTION
The global selector must use a proper CSS class selector to target the custom-dropzone class correctly.