### PR TITLE
Add types + Improve bundle output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,53 +1,55 @@
 {
-  "name": "svelte-file-dropzone",
-  "version": "0.0.15",
-  "description": "Svelte component for fileupload and file dropzone",
-  "svelte": "src/components/Dropzone.svelte",
-  "module": "dist/index.mjs",
-  "main": "dist/index.js",
-  "scripts": {
-    "build": "rollup -c",
-    "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
-  },
-  "repository": {
-    "url": "https://github.com/thecodejack/svelte-file-dropzone"
-  },
-  "author": "thecodejack",
-  "license": "MIT",
-  "dependencies": {
-    "file-selector": "^0.2.2"
-  },
-  "devDependencies": {
-    "@babel/core": "7.14.6",
-    "@rollup/plugin-commonjs": "18.0.0",
-    "@rollup/plugin-node-resolve": "11.2.1",
-    "@storybook/addon-actions": "6.2.9",
-    "@storybook/addon-links": "6.2.9",
-    "@storybook/addon-notes": "5.3.21",
-    "@storybook/addon-storysource": "6.2.9",
-    "@storybook/addons": "6.2.9",
-    "@storybook/svelte": "6.2.9",
-    "babel-loader": "8.2.2",
-    "rollup": "2.46.0",
-    "rollup-plugin-svelte": "7.1.0",
-    "svelte": "3.41.0",
-    "svelte-loader": "3.1.1"
-  },
-  "keywords": [
-    "svelte",
-    "svelte3",
-    "svelte-components",
-    "upload",
-    "dropzone",
-    "svelte-file-dropzone",
-    "svelte-dropzone",
-    "sveltejs"
-  ],
-  "files": [
-    "src",
-    "dist"
-  ]
+    "name": "svelte-file-dropzone",
+    "version": "0.0.15",
+    "description": "Svelte component for fileupload and file dropzone",
+    "svelte": "src/components/Dropzone.svelte",
+    "module": "dist/index.mjs",
+    "main": "dist/index.js",
+    "scripts": {
+        "build": "rollup -c && node scripts/genTypes.js",
+        "prepublishOnly": "npm run build",
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "storybook": "start-storybook -p 6006",
+        "build-storybook": "build-storybook"
+    },
+    "repository": {
+        "url": "https://github.com/thecodejack/svelte-file-dropzone"
+    },
+    "author": "thecodejack",
+    "license": "MIT",
+    "dependencies": {
+        "file-selector": "^0.2.2"
+    },
+    "devDependencies": {
+        "@babel/core": "7.14.6",
+        "@rollup/plugin-commonjs": "18.0.0",
+        "@rollup/plugin-node-resolve": "11.2.1",
+        "@storybook/addon-actions": "6.2.9",
+        "@storybook/addon-links": "6.2.9",
+        "@storybook/addon-notes": "5.3.21",
+        "@storybook/addon-storysource": "6.2.9",
+        "@storybook/addons": "6.2.9",
+        "@storybook/svelte": "6.2.9",
+        "babel-loader": "8.2.2",
+        "rollup": "2.46.0",
+        "rollup-plugin-css-only": "^3.1.0",
+        "rollup-plugin-svelte": "7.1.0",
+        "sveld": "^0.15.0",
+        "svelte": "3.41.0",
+        "svelte-loader": "3.1.1"
+    },
+    "keywords": [
+        "svelte",
+        "svelte3",
+        "svelte-components",
+        "upload",
+        "dropzone",
+        "svelte-file-dropzone",
+        "svelte-dropzone",
+        "sveltejs"
+    ],
+    "files": [
+        "src",
+        "dist"
+    ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,17 +2,17 @@ import svelte from "rollup-plugin-svelte";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import pkg from "./package.json";
-
+import css from 'rollup-plugin-css-only';
 const name = pkg.name
   .replace(/^(@\S+\/)?(svelte-)?(\S+)/, "$3")
   .replace(/^\w/, (m) => m.toUpperCase())
   .replace(/-\w/g, (m) => m[1].toUpperCase());
 
 export default {
-  input: "src/index.svelte",
+  input: "src/index.js",
   output: [
     { file: pkg.module, format: "es" },
     { file: pkg.main, format: "umd", name },
   ],
-  plugins: [svelte(), resolve(), commonjs()],
+  plugins: [svelte(), css({output: "index.css"}), resolve(), commonjs()],
 };

--- a/scripts/genTypes.js
+++ b/scripts/genTypes.js
@@ -1,0 +1,10 @@
+const { sveld } = require("sveld");
+const pkg = require("../package.json");
+const path = require('path');
+
+sveld({
+  input: "./src/index.js",
+  typesOptions: {
+    outDir: path.dirname(pkg.main)
+  }
+})

--- a/src/components/Dropzone.svelte
+++ b/src/components/Dropzone.svelte
@@ -1,356 +1,362 @@
 <script>
-  import { fromEvent } from "file-selector";
-  import {
-    allFilesAccepted,
-    composeEventHandlers,
-    fileAccepted,
-    fileMatchSize,
-    isEvtWithFiles,
-    isIeOrEdge,
-    isPropagationStopped,
-    onDocumentDragOver,
-    TOO_MANY_FILES_REJECTION
-  } from "./../utils/index";
-  import { onMount, onDestroy, createEventDispatcher } from "svelte";
+    import { fromEvent } from "file-selector";
+    import {
+        allFilesAccepted,
+        composeEventHandlers,
+        fileAccepted,
+        fileMatchSize,
+        isEvtWithFiles,
+        isIeOrEdge,
+        isPropagationStopped,
+        onDocumentDragOver,
+        TOO_MANY_FILES_REJECTION,
+    } from "./../utils/index";
+    import { onMount, onDestroy, createEventDispatcher } from "svelte";
 
-  //props
-  /**
-   * Set accepted file types.
-   * See https://github.com/okonet/attr-accept for more information.
-   */
-  export let accept; // string or string[]
-  export let disabled = false;
-  export let getFilesFromEvent = fromEvent;
-  export let maxSize = Infinity;
-  export let minSize = 0;
-  export let multiple = true;
-  export let preventDropOnDocument = true;
-  export let noClick = false;
-  export let noKeyboard = false;
-  export let noDrag = false;
-  export let noDragEventsBubbling = false;
-  export let containerClasses = "";
-  export let containerStyles = "";
-  export let disableDefaultStyles = false;
+    //props
+    /**
+     * Set accepted file types.
+     * See https://github.com/okonet/attr-accept for more information.
+     */
 
-  const dispatch = createEventDispatcher();
+    /** @type {string | string[]} */
+    export let accept;
+    export let disabled = false;
+    /** @type {typeof import("file-selector").fromEvent} */
+    export let getFilesFromEvent = fromEvent;
+    /** @type {number} */
+    export let maxSize = Infinity;
+    export let minSize = 0;
+    export let multiple = true;
+    export let preventDropOnDocument = true;
+    export let noClick = false;
+    export let noKeyboard = false;
+    export let noDrag = false;
+    export let noDragEventsBubbling = false;
+    export let containerClasses = "";
+    export let containerStyles = "";
+    export let disableDefaultStyles = false;
 
-  //state
+    const dispatch = createEventDispatcher();
 
-  let state = {
-    isFocused: false,
-    isFileDialogActive: false,
-    isDragActive: false,
-    isDragAccept: false,
-    isDragReject: false,
-    draggedFiles: [],
-    acceptedFiles: [],
-    fileRejections: []
-  };
+    //state
 
-  let rootRef;
-  let inputRef;
+    let state = {
+        isFocused: false,
+        isFileDialogActive: false,
+        isDragActive: false,
+        isDragAccept: false,
+        isDragReject: false,
+        draggedFiles: [],
+        acceptedFiles: [],
+        fileRejections: [],
+    };
 
-  function resetState() {
-    state.isFileDialogActive = false;
-    state.isDragActive = false;
-    state.draggedFiles = [];
-    state.acceptedFiles = [];
-    state.fileRejections = [];
-  }
+    let rootRef;
+    let inputRef;
 
-  // Fn for opening the file dialog programmatically
-  function openFileDialog() {
-    if (inputRef) {
-      inputRef.value = null; // TODO check if null needs to be set
-      state.isFileDialogActive = true;
-      inputRef.click();
-    }
-  }
-
-  // Cb to open the file dialog when SPACE/ENTER occurs on the dropzone
-  function onKeyDownCb(event) {
-    // Ignore keyboard events bubbling up the DOM tree
-    if (!rootRef || !rootRef.isEqualNode(event.target)) {
-      return;
+    function resetState() {
+        state.isFileDialogActive = false;
+        state.isDragActive = false;
+        state.draggedFiles = [];
+        state.acceptedFiles = [];
+        state.fileRejections = [];
     }
 
-    if (event.keyCode === 32 || event.keyCode === 13) {
-      event.preventDefault();
-      openFileDialog();
-    }
-  }
-
-  // Update focus state for the dropzone
-  function onFocusCb() {
-    state.isFocused = true;
-  }
-  function onBlurCb() {
-    state.isFocused = false;
-  }
-
-  // Cb to open the file dialog when click occurs on the dropzone
-  function onClickCb() {
-    if (noClick) {
-      return;
-    }
-
-    // In IE11/Edge the file-browser dialog is blocking, therefore, use setTimeout()
-    // to ensure React can handle state changes
-    // See: https://github.com/react-dropzone/react-dropzone/issues/450
-    if (isIeOrEdge()) {
-      setTimeout(openFileDialog, 0);
-    } else {
-      openFileDialog();
-    }
-  }
-
-  function onDragEnterCb(event) {
-    event.preventDefault();
-    stopPropagation(event);
-
-    dragTargetsRef = [...dragTargetsRef, event.target];
-
-    if (isEvtWithFiles(event)) {
-      Promise.resolve(getFilesFromEvent(event)).then(draggedFiles => {
-        if (isPropagationStopped(event) && !noDragEventsBubbling) {
-          return;
-        }
-
-        state.draggedFiles = draggedFiles;
-        state.isDragActive = true;
-
-        dispatch("dragenter", {
-          dragEvent: event
-        });
-      });
-    }
-  }
-
-  function onDragOverCb(event) {
-    event.preventDefault();
-    stopPropagation(event);
-
-    if (event.dataTransfer) {
-      try {
-        event.dataTransfer.dropEffect = "copy";
-      } catch {} /* eslint-disable-line no-empty */
-    }
-
-    if (isEvtWithFiles(event)) {
-      dispatch("dragover", {
-        dragEvent: event
-      });
-    }
-
-    return false;
-  }
-
-  function onDragLeaveCb(event) {
-    event.preventDefault();
-    stopPropagation(event);
-
-    // Only deactivate once the dropzone and all children have been left
-    const targets = dragTargetsRef.filter(
-      target => rootRef && rootRef.contains(target)
-    );
-    // Make sure to remove a target present multiple times only once
-    // (Firefox may fire dragenter/dragleave multiple times on the same element)
-    const targetIdx = targets.indexOf(event.target);
-    if (targetIdx !== -1) {
-      targets.splice(targetIdx, 1);
-    }
-    dragTargetsRef = targets;
-    if (targets.length > 0) {
-      return;
-    }
-
-    state.isDragActive = false;
-    state.draggedFiles = [];
-
-    if (isEvtWithFiles(event)) {
-      dispatch("dragleave", {
-        dragEvent: event
-      });
-    }
-  }
-
-  function onDropCb(event) {
-    event.preventDefault();
-    stopPropagation(event);
-
-    dragTargetsRef = [];
-
-    if (isEvtWithFiles(event)) {
-      dispatch("filedropped", {
-        event
-      })
-      Promise.resolve(getFilesFromEvent(event)).then(files => {
-        if (isPropagationStopped(event) && !noDragEventsBubbling) {
-          return;
-        }
-
-        const acceptedFiles = [];
-        const fileRejections = [];
-
-        files.forEach(file => {
-          const [accepted, acceptError] = fileAccepted(file, accept);
-          const [sizeMatch, sizeError] = fileMatchSize(file, minSize, maxSize);
-          if (accepted && sizeMatch) {
-            acceptedFiles.push(file);
-          } else {
-            const errors = [acceptError, sizeError].filter(e => e);
-            fileRejections.push({ file, errors });
-          }
-        });
-
-        if (!multiple && acceptedFiles.length > 1) {
-          // Reject everything and empty accepted files
-          acceptedFiles.forEach(file => {
-            fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] });
-          });
-          acceptedFiles.splice(0);
-        }
-
-        state.acceptedFiles = acceptedFiles;
-        state.fileRejections = fileRejections;
-
-        dispatch("drop", {
-          acceptedFiles,
-          fileRejections,
-          event
-        });
-
-        if (fileRejections.length > 0) {
-          dispatch("droprejected", {
-            fileRejections,
-            event
-          });
-        }
-
-        if (acceptedFiles.length > 0) {
-          dispatch("dropaccepted", {
-            acceptedFiles,
-            event
-          });
-        }
-      });
-    }
-    resetState();
-  }
-
-  function composeHandler(fn) {
-    return disabled ? null : fn;
-  }
-
-  function composeKeyboardHandler(fn) {
-    return noKeyboard ? null : composeHandler(fn);
-  }
-
-  function composeDragHandler(fn) {
-    return noDrag ? null : composeHandler(fn);
-  }
-
-  function stopPropagation(event) {
-    if (noDragEventsBubbling) {
-      event.stopPropagation();
-    }
-  }
-
-  let dragTargetsRef = [];
-  function onDocumentDrop(event) {
-    if (rootRef && rootRef.contains(event.target)) {
-      // If we intercepted an event for our instance, let it propagate down to the instance's onDrop handler
-      return;
-    }
-    event.preventDefault();
-    dragTargetsRef = [];
-  }
-
-  // Update file dialog active state when the window is focused on
-  function onWindowFocus() {
-    // Execute the timeout only if the file dialog is opened in the browser
-    if (state.isFileDialogActive) {
-      setTimeout(() => {
+    // Fn for opening the file dialog programmatically
+    function openFileDialog() {
         if (inputRef) {
-          const { files } = inputRef;
-
-          if (!files.length) {
-            state.isFileDialogActive = false;
-            dispatch("filedialogcancel");
-          }
+            inputRef.value = null; // TODO check if null needs to be set
+            state.isFileDialogActive = true;
+            inputRef.click();
         }
-      }, 300);
     }
-  }
 
-  onMount(() => {
-    window.addEventListener("focus", onWindowFocus, false);
-    if (preventDropOnDocument) {
-      document.addEventListener("dragover", onDocumentDragOver, false);
-      document.addEventListener("drop", onDocumentDrop, false);
+    // Cb to open the file dialog when SPACE/ENTER occurs on the dropzone
+    function onKeyDownCb(event) {
+        // Ignore keyboard events bubbling up the DOM tree
+        if (!rootRef || !rootRef.isEqualNode(event.target)) {
+            return;
+        }
+
+        if (event.keyCode === 32 || event.keyCode === 13) {
+            event.preventDefault();
+            openFileDialog();
+        }
     }
-  });
 
-  onDestroy(() => {
-    window.removeEventListener("focus", onWindowFocus, false);
-    if (preventDropOnDocument) {
-      document.removeEventListener("dragover", onDocumentDragOver);
-      document.removeEventListener("drop", onDocumentDrop);
+    // Update focus state for the dropzone
+    function onFocusCb() {
+        state.isFocused = true;
     }
-  });
+    function onBlurCb() {
+        state.isFocused = false;
+    }
 
-  function onInputElementClick(event) {
-    event.stopPropagation();
-  }
+    // Cb to open the file dialog when click occurs on the dropzone
+    function onClickCb() {
+        if (noClick) {
+            return;
+        }
+
+        // In IE11/Edge the file-browser dialog is blocking, therefore, use setTimeout()
+        // to ensure React can handle state changes
+        // See: https://github.com/react-dropzone/react-dropzone/issues/450
+        if (isIeOrEdge()) {
+            setTimeout(openFileDialog, 0);
+        } else {
+            openFileDialog();
+        }
+    }
+
+    function onDragEnterCb(event) {
+        event.preventDefault();
+        stopPropagation(event);
+
+        dragTargetsRef = [...dragTargetsRef, event.target];
+
+        if (isEvtWithFiles(event)) {
+            Promise.resolve(getFilesFromEvent(event)).then((draggedFiles) => {
+                if (isPropagationStopped(event) && !noDragEventsBubbling) {
+                    return;
+                }
+
+                state.draggedFiles = draggedFiles;
+                state.isDragActive = true;
+
+                dispatch("dragenter", {
+                    dragEvent: event,
+                });
+            });
+        }
+    }
+
+    function onDragOverCb(event) {
+        event.preventDefault();
+        stopPropagation(event);
+
+        if (event.dataTransfer) {
+            try {
+                event.dataTransfer.dropEffect = "copy";
+            } catch {} /* eslint-disable-line no-empty */
+        }
+
+        if (isEvtWithFiles(event)) {
+            dispatch("dragover", {
+                dragEvent: event,
+            });
+        }
+
+        return false;
+    }
+
+    function onDragLeaveCb(event) {
+        event.preventDefault();
+        stopPropagation(event);
+
+        // Only deactivate once the dropzone and all children have been left
+        const targets = dragTargetsRef.filter(
+            (target) => rootRef && rootRef.contains(target)
+        );
+        // Make sure to remove a target present multiple times only once
+        // (Firefox may fire dragenter/dragleave multiple times on the same element)
+        const targetIdx = targets.indexOf(event.target);
+        if (targetIdx !== -1) {
+            targets.splice(targetIdx, 1);
+        }
+        dragTargetsRef = targets;
+        if (targets.length > 0) {
+            return;
+        }
+
+        state.isDragActive = false;
+        state.draggedFiles = [];
+
+        if (isEvtWithFiles(event)) {
+            dispatch("dragleave", {
+                dragEvent: event,
+            });
+        }
+    }
+
+    function onDropCb(event) {
+        event.preventDefault();
+        stopPropagation(event);
+
+        dragTargetsRef = [];
+
+        if (isEvtWithFiles(event)) {
+            dispatch("filedropped", {
+                event,
+            });
+            Promise.resolve(getFilesFromEvent(event)).then((files) => {
+                if (isPropagationStopped(event) && !noDragEventsBubbling) {
+                    return;
+                }
+
+                const acceptedFiles = [];
+                const fileRejections = [];
+
+                files.forEach((file) => {
+                    const [accepted, acceptError] = fileAccepted(file, accept);
+                    const [sizeMatch, sizeError] = fileMatchSize(file, minSize, maxSize);
+                    if (accepted && sizeMatch) {
+                        acceptedFiles.push(file);
+                    } else {
+                        const errors = [acceptError, sizeError].filter((e) => e);
+                        fileRejections.push({ file, errors });
+                    }
+                });
+
+                if (!multiple && acceptedFiles.length > 1) {
+                    // Reject everything and empty accepted files
+                    acceptedFiles.forEach((file) => {
+                        fileRejections.push({ file, errors: [TOO_MANY_FILES_REJECTION] });
+                    });
+                    acceptedFiles.splice(0);
+                }
+
+                state.acceptedFiles = acceptedFiles;
+                state.fileRejections = fileRejections;
+
+                dispatch("drop", {
+                    acceptedFiles,
+                    fileRejections,
+                    event,
+                });
+
+                if (fileRejections.length > 0) {
+                    dispatch("droprejected", {
+                        fileRejections,
+                        event,
+                    });
+                }
+
+                if (acceptedFiles.length > 0) {
+                    dispatch("dropaccepted", {
+                        acceptedFiles,
+                        event,
+                    });
+                }
+            });
+        }
+        resetState();
+    }
+
+    function composeHandler(fn) {
+        return disabled ? null : fn;
+    }
+
+    function composeKeyboardHandler(fn) {
+        return noKeyboard ? null : composeHandler(fn);
+    }
+
+    function composeDragHandler(fn) {
+        return noDrag ? null : composeHandler(fn);
+    }
+
+    function stopPropagation(event) {
+        if (noDragEventsBubbling) {
+            event.stopPropagation();
+        }
+    }
+
+    let dragTargetsRef = [];
+    function onDocumentDrop(event) {
+        if (rootRef && rootRef.contains(event.target)) {
+            // If we intercepted an event for our instance, let it propagate down to the instance's onDrop handler
+            return;
+        }
+        event.preventDefault();
+        dragTargetsRef = [];
+    }
+
+    // Update file dialog active state when the window is focused on
+    function onWindowFocus() {
+        // Execute the timeout only if the file dialog is opened in the browser
+        if (state.isFileDialogActive) {
+            setTimeout(() => {
+                if (inputRef) {
+                    const { files } = inputRef;
+
+                    if (!files.length) {
+                        state.isFileDialogActive = false;
+                        dispatch("filedialogcancel");
+                    }
+                }
+            }, 300);
+        }
+    }
+
+    onMount(() => {
+        window.addEventListener("focus", onWindowFocus, false);
+        if (preventDropOnDocument) {
+            document.addEventListener("dragover", onDocumentDragOver, false);
+            document.addEventListener("drop", onDocumentDrop, false);
+        }
+    });
+
+    onDestroy(() => {
+        window.removeEventListener("focus", onWindowFocus, false);
+        if (preventDropOnDocument) {
+            document.removeEventListener("dragover", onDocumentDragOver);
+            document.removeEventListener("drop", onDocumentDrop);
+        }
+    });
+
+    function onInputElementClick(event) {
+        event.stopPropagation();
+    }
 </script>
 
-<style>
-  .dropzone {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 20px;
-    border-width: 2px;
-    border-radius: 2px;
-    border-color: #eeeeee;
-    border-style: dashed;
-    background-color: #fafafa;
-    color: #bdbdbd;
-    outline: none;
-    transition: border 0.24s ease-in-out;
-  }
-  .dropzone:focus {
-    border-color: #2196f3;
-  }
-</style>
-
 <div
-  bind:this={rootRef}
-  tabindex="0"
-  class="{disableDefaultStyles ? '' : 'dropzone'}
+    bind:this="{rootRef}"
+    tabindex="0"
+    class="{disableDefaultStyles ? '' : 'dropzone'}
   {containerClasses}"
-  style={containerStyles}
-  on:keydown={composeKeyboardHandler(onKeyDownCb)}
-  on:focus={composeKeyboardHandler(onFocusCb)}
-  on:blur={composeKeyboardHandler(onBlurCb)}
-  on:click={composeHandler(onClickCb)}
-  on:dragenter={composeDragHandler(onDragEnterCb)}
-  on:dragover={composeDragHandler(onDragOverCb)}
-  on:dragleave={composeDragHandler(onDragLeaveCb)}
-  on:drop={composeDragHandler(onDropCb)}>
-  <input
-    {accept}
-    {multiple}
-    type="file"
-    autocomplete="off"
-    tabindex="-1"
-    on:change={onDropCb}
-    on:click={onInputElementClick}
-    bind:this={inputRef}
-    style="display: none;" />
-  <slot>
-    <p>Drag 'n' drop some files here, or click to select files</p>
-  </slot>
+    style="{containerStyles}"
+    on:keydown="{composeKeyboardHandler(onKeyDownCb)}"
+    on:focus="{composeKeyboardHandler(onFocusCb)}"
+    on:blur="{composeKeyboardHandler(onBlurCb)}"
+    on:click="{composeHandler(onClickCb)}"
+    on:dragenter="{composeDragHandler(onDragEnterCb)}"
+    on:dragover="{composeDragHandler(onDragOverCb)}"
+    on:dragleave="{composeDragHandler(onDragLeaveCb)}"
+    on:drop="{composeDragHandler(onDropCb)}"
+>
+    <input
+        accept="{accept}"
+        multiple="{multiple}"
+        type="file"
+        autocomplete="off"
+        tabindex="-1"
+        on:change="{onDropCb}"
+        on:click="{onInputElementClick}"
+        bind:this="{inputRef}"
+        style="display: none;"
+    />
+    <slot>
+        <p>Drag 'n' drop some files here, or click to select files</p>
+    </slot>
 </div>
+
+<style>
+    .dropzone {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 20px;
+        border-width: 2px;
+        border-radius: 2px;
+        border-color: #eeeeee;
+        border-style: dashed;
+        background-color: #fafafa;
+        color: #bdbdbd;
+        outline: none;
+        transition: border 0.24s ease-in-out;
+    }
+    .dropzone:focus {
+        border-color: #2196f3;
+    }
+</style>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -1,3 +1,0 @@
-import DropZone from "./components/Dropzone.svelte";
-
-export default DropZone;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1759,6 +1759,26 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
+"@rollup/plugin-node-resolve@^13.2.0":
+  version "13.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz#cdee815cf02c180ff0a42536ca67a8f67e299f84"
+  integrity sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/pluginutils@4":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -2596,6 +2616,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/pug@^2.0.4":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"
+  integrity sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
+
 "@types/qs@^6.9.5":
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
@@ -2649,6 +2674,13 @@
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/sass@^1.16.0":
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.43.1.tgz#86bb0168e9e881d7dade6eba16c9ed6d25dc2f68"
+  integrity sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==
   dependencies:
     "@types/node" "*"
 
@@ -2894,6 +2926,11 @@ acorn@^7.3.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -3433,7 +3470,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3558,6 +3595,11 @@ browserslist@^4.16.6:
     electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
     node-releases "^1.1.71"
+
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -3956,6 +3998,11 @@ commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+comment-parser@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
+  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4371,6 +4418,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-indent@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
@@ -4749,6 +4801,11 @@ es5-shim@^4.5.13:
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.14.tgz#90009e1019d0ea327447cb523deaff8fe45697ef"
   integrity sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==
 
+es6-promise@^3.1.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
+
 es6-shim@^0.35.5:
   version "0.35.5"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.5.tgz#46f59dc0a84a1c5029e8ff1166ca0a902077a9ab"
@@ -5047,6 +5104,17 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
     picomatch "^2.2.1"
+
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -5374,7 +5442,7 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fsevents@~2.3.1:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -5471,7 +5539,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.0:
+glob-parent@^5.1.0, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -5582,6 +5650,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.3:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 gud@^1.0.0:
   version "1.0.0"
@@ -6731,6 +6804,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -6767,6 +6848,11 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -7461,6 +7547,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
@@ -7631,6 +7722,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 prettier@~2.2.1:
   version "2.2.1"
@@ -8396,7 +8492,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -8418,7 +8514,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-svelte@7.1.0:
+rollup-plugin-css-only@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz#6a701cc5b051c6b3f0961e69b108a9a118e1b1df"
+  integrity sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==
+  dependencies:
+    "@rollup/pluginutils" "4"
+
+rollup-plugin-svelte@7.1.0, rollup-plugin-svelte@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-7.1.0.tgz#d45f2b92b1014be4eb46b55aa033fb9a9c65f04d"
   integrity sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==
@@ -8439,6 +8542,13 @@ rollup@2.46.0:
   integrity sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==
   optionalDependencies:
     fsevents "~2.3.1"
+
+rollup@^2.70.1:
+  version "2.70.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.2.tgz#808d206a8851628a065097b7ba2053bd83ba0c0d"
+  integrity sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 run-parallel@^1.1.9:
   version "1.2.0"
@@ -8480,6 +8590,16 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sander@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad"
+  integrity sha1-dB4kXiMfB8r7b98PEzrfohalAq0=
+  dependencies:
+    es6-promise "^3.1.2"
+    graceful-fs "^4.1.3"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.2"
 
 scheduler@^0.19.1:
   version "0.19.1"
@@ -8760,6 +8880,16 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+sorcery@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7"
+  integrity sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=
+  dependencies:
+    buffer-crc32 "^0.2.5"
+    minimist "^1.2.0"
+    sander "^0.5.0"
+    sourcemap-codec "^1.3.0"
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -8804,7 +8934,7 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.3.0, sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -9047,6 +9177,13 @@ strip-ansi@^5.1.0:
   dependencies:
     ansi-regex "^4.1.0"
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 strip-json-comments@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -9081,6 +9218,22 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+sveld@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/sveld/-/sveld-0.15.0.tgz#826a1064f67f234bd415582b400b4d80b164ac8e"
+  integrity sha512-qBo/6q2QAsAkEAIvz4uTX2mSAhJ5MNtOB+ntpLVoVnKJlNGpqKQgjsMGB8mfa1vF+BDZemtf+tLDq+sPNpxxUA==
+  dependencies:
+    "@rollup/plugin-node-resolve" "^13.2.0"
+    acorn "^8.7.0"
+    comment-parser "^1.3.1"
+    fast-glob "^3.2.11"
+    prettier "^2.6.2"
+    rollup "^2.70.1"
+    rollup-plugin-svelte "^7.1.0"
+    svelte "^3.47.0"
+    svelte-preprocess "^4.10.6"
+    typescript "^4.6.3"
+
 svelte-dev-helper@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/svelte-dev-helper/-/svelte-dev-helper-1.1.9.tgz#7d187db5c6cdbbd64d75a32f91b8998bde3273c3"
@@ -9100,10 +9253,27 @@ svelte-loader@3.1.1:
     svelte-dev-helper "^1.1.9"
     svelte-hmr "^0.12.3"
 
+svelte-preprocess@^4.10.6:
+  version "4.10.6"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.6.tgz#5f9a53e7ed3b85fc7e0841120c725b76ac5a1ba8"
+  integrity sha512-I2SV1w/AveMvgIQlUF/ZOO3PYVnhxfcpNyGt8pxpUVhPfyfL/CZBkkw/KPfuFix5FJ9TnnNYMhACK3DtSaYVVQ==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    magic-string "^0.25.7"
+    sorcery "^0.10.0"
+    strip-indent "^3.0.0"
+
 svelte@3.41.0:
   version "3.41.0"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.41.0.tgz#2009fd6681453ffb8b5aaa57f4a89a8be3dedd78"
   integrity sha512-X9/lnTcRBCrMdyFBVjfmqy1T2vyN8ejUE1OfbWSccc2Z42Amn3ab3XdBgVl+oDkZvzPfPMoxo6CEbWca7pXOew==
+
+svelte@^3.47.0:
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.47.0.tgz#ba46fe4aea99fc650d6939c215cd4694f5325a19"
+  integrity sha512-4JaJp3HEoTCGARRWZQIZDUanhYv0iyoHikklVHVLH9xFE9db22g4TDv7CPeNA8HD1JgjXI1vlhR1JZvvhaTu2Q==
 
 sveltedoc-parser@^4.1.0:
   version "4.1.0"
@@ -9381,6 +9551,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
This pull request adds types for this component. In addition, I noticed the bundle output is invalid and the CSS output is missing. It has no effect on sveltekit or Rollup because they use the "svelte" field directly from package.json. but if it used standalone, it will be broken. I fixed that and removed the index.svelte file because Rollup will treat it as Svelte component and will compile it in the bundle.