### PR TITLE
fix: changed exports to '.' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-storybook": "storybook build"
   },
   "exports": {
-    "./Dropzone.svelte": {
+    ".": {
       "types": "./dist/components/Dropzone.svelte.d.ts",
       "svelte": "./dist/components/Dropzone.svelte"
     }


### PR DESCRIPTION
Since I tried to upgrade vitest from 0.33.0 to 0.34.0 or above, vitest gives the following error.

```shell
Error: Failed to resolve entry for package "svelte-file-dropzone". The package may have incorrect main/module/exports specified in its package.json: Missing "." specifier in "svelte-file-dropzone" package
 ❯ packageEntryFailure ../../node_modules/vite/dist/node/chunks/dep-df561101.js:28691:11
 ❯ resolvePackageEntry ../../node_modules/vite/dist/node/chunks/dep-df561101.js:28686:9
 ❯ tryNodeResolve ../../node_modules/vite/dist/node/chunks/dep-df561101.js:28419:20
 ❯ Context.resolveId ../../node_modules/vite/dist/node/chunks/dep-df561101.js:28180:28
 ❯ Object.resolveId ../../node_modules/vite/dist/node/chunks/dep-df561101.js:44207:64
 ❯ async file:/Users/j_igarashi/Documents/git/UNDP-Data/geohub/node_modules/vite/dist/node/chunks/dep-df561101.js:65837:21
 ❯ async file:/Users/j_igarashi/Documents/git/UNDP-Data/geohub/node_modules/vite/dist/node/chunks/dep-df561101.js:44852:20
 ❯ addManuallyIncludedOptimizeDeps ../../node_modules/vite/dist/node/chunks/dep-df561101.js:46034:31
 ❯ optimizeServerSsrDeps ../../node_modules/vite/dist/node/chunks/dep-df561101.js:45638:5
 ❯ createDevSsrDepsOptimizer ../../node_modules/vite/dist/node/chunks/dep-df561101.js:45556:22
```

Looks like `exports` property in package.json must have `.`. I just changed it to `.`.

For your reference, the following package.json is the template generated by the latest sveltekit. It may need `svelte` property and `types` property as well, but I believe this PR's change is enough to pass vitest 0.34.0.

<details>

<summary>Default package.json by sveltekit template</summary>

```json
{
	"name": "test",
	"version": "0.0.1",
	"scripts": {
		"dev": "vite dev",
		"build": "vite build && npm run package",
		"preview": "vite preview",
		"package": "svelte-kit sync && svelte-package && publint",
		"prepublishOnly": "npm run package",
		"test": "npm run test:integration && npm run test:unit",
		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
		"lint": "prettier --plugin-search-dir . --check . && eslint .",
		"format": "prettier --plugin-search-dir . --write .",
		"test:integration": "playwright test",
		"test:unit": "vitest"
	},
	"exports": {
		".": {
			"types": "./dist/index.d.ts",
			"svelte": "./dist/index.js"
		}
	},
	"files": [
		"dist",
		"!dist/**/*.test.*",
		"!dist/**/*.spec.*"
	],
	"peerDependencies": {
		"svelte": "^4.0.0"
	},
	"devDependencies": {
		"@playwright/test": "^1.28.1",
		"@sveltejs/adapter-auto": "^2.0.0",
		"@sveltejs/kit": "^1.20.4",
		"@sveltejs/package": "^2.0.0",
		"@typescript-eslint/eslint-plugin": "^5.45.0",
		"@typescript-eslint/parser": "^5.45.0",
		"eslint": "^8.28.0",
		"eslint-config-prettier": "^8.5.0",
		"eslint-plugin-svelte": "^2.30.0",
		"prettier": "^2.8.0",
		"prettier-plugin-svelte": "^2.10.1",
		"publint": "^0.1.9",
		"svelte": "^4.0.5",
		"svelte-check": "^3.4.3",
		"tslib": "^2.4.1",
		"typescript": "^5.0.0",
		"vite": "^4.4.2",
		"vitest": "^0.32.2"
	},
	"svelte": "./dist/index.js",
	"types": "./dist/index.d.ts",
	"type": "module"
}
```

</details>