### PR TITLE
fix: vitest error 'Cannot find '.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-dist
 storybook-static

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+dist
 node_modules
 storybook-static

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "description": "Svelte component for fileupload and file dropzone",
   "scripts": {
+    "prepare": "npm run package",
     "package": "svelte-kit sync && svelte-package && publint",
     "prepublishOnly": "npm run package",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,6 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
-    },
-    "./Dropzone.svelte": {
       "types": "./dist/components/Dropzone.svelte.d.ts",
       "svelte": "./dist/components/Dropzone.svelte"
     }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "build-storybook": "storybook build"
   },
   "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js"
+    },
     "./Dropzone.svelte": {
       "types": "./dist/components/Dropzone.svelte.d.ts",
       "svelte": "./dist/components/Dropzone.svelte"

--- a/package.json
+++ b/package.json
@@ -10,19 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
-  "exports": {
-    ".": {
-      "types": "./dist/components/Dropzone.svelte.d.ts",
-      "svelte": "./dist/components/Dropzone.svelte"
-    }
-  },
-  "typesVersions": {
-    ">4.0": {
-      ".": [
-        "./dist/components/Dropzone.svelte.d.ts"
-      ]
-    }
-  },
+  "main": "./dist/components/Dropzone.svelte",
+  "types": "./dist/components/Dropzone.svelte.d.ts",
   "repository": {
     "url": "https://github.com/thecodejack/svelte-file-dropzone"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "typesVersions": {
     ">4.0": {
-      "Dropzone.svelte": [
+      ".": [
         "./dist/components/Dropzone.svelte.d.ts"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.2",
   "description": "Svelte component for fileupload and file dropzone",
   "scripts": {
-    "prepare": "npm run package",
     "package": "svelte-kit sync && svelte-package && publint",
+    "prepare": "npm run package",
     "prepublishOnly": "npm run package",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
Fixes issue https://github.com/thecodejack/svelte-file-dropzone/issues/147 by adding an empty index file.