### PR TITLE
Fix import of Dropzone.svelte when using `npm link`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "svelte": "./dist/index.js"
+    },
+    "./Dropzone.svelte": {
+      "types": "./dist/components/Dropzone.svelte.d.ts",
+      "svelte": "./dist/components/Dropzone.svelte"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
Fixes #151 